### PR TITLE
autowrite MAC address to CSM_mac

### DIFF
--- a/install
+++ b/install
@@ -65,5 +65,12 @@ CSM_add_network --no-password --priority=1 CSMguest
 #      write MAC address to boot (CSM_mac.txt)
 # ===================================================
 
-#adds mac address to file in boot called "CSM_mac.txt"
-CSM_get_mac wlan0 > /boot/CSM_mac.txt
+# adds mac address to file in boot called "CSM_mac.txt"
+WRITE_MAC_COMMAND="CSM_get_mac wlan0 > /boot/CSM_mac.txt"
+WRITE_MAC_CRON="@reboot $WRITE_MAC_COMMAND"
+crontab -l >/tmp/crontab_r 2>/dev/null
+grep -Fx "$WRITE_MAC_CRON" /tmp/crontab_r >/dev/null
+if [ "$?" -ne 0 ]; then
+    echo "$WRITE_MAC_CRON">>/tmp/crontab_r
+fi
+crontab /tmp/crontab_r


### PR DESCRIPTION
writes to /boot, which can be accessed on windows machine

# Description of changes
allows for end user to access MAC while headless (at boot)

# Outstanding changes

# Outstanding questions

# Documentation updates
- [x] I updated usage documentation as appropriate
- [x] I updated installation documentation as appropriate
- [x] I updated implementation documentation as appropriate
- [x] I updated technical considerations documentation as appropriate

# Issues closed

close #43
