### PR TITLE
fixed CSM_get_mac to have usable functions

### DIFF
--- a/src/scripts/CSM_get_mac.py
+++ b/src/scripts/CSM_get_mac.py
@@ -13,11 +13,11 @@ def getMAC(c_type) -> str:
         str: MAC address
     """
     try:
-        str = netifaces.ifaddresses(c_type)[netifaces.AF_LINK][0]['addr']
+        mac = netifaces.ifaddresses(c_type)[netifaces.AF_LINK][0]['addr']
     except:
         print("Error")
         sys.exit(1)
-    return str[0:17]
+    return mac
 
 
 def user_input() -> str:
@@ -32,10 +32,10 @@ def user_input() -> str:
             "What is your connection type? (ethernet, wireless)\n")
         if connection.lower() == 'ethernet':
             c_type = 'eth0'
-            input_bool = True
+            break
         elif connection.lower() == 'wifi' or connection.lower() == 'wireless':
             c_type = 'wlan0'
-            input_bool = True
+            break
     return c_type
 
 


### PR DESCRIPTION


# Description of changes
can now pass in a connection type interface (wlan0, eth0) to the getMAC() function

# Outstanding changes

# Outstanding questions

# Documentation updates
- [x] I updated usage documentation as appropriate
- [x] I updated installation documentation as appropriate
- [x] I updated implementation documentation as appropriate
- [x] I updated technical considerations documentation as appropriate

# Issues closed
