### PR TITLE
Convert generate_request to use 'requests' library

### DIFF
--- a/src/autopi/generate_request.py
+++ b/src/autopi/generate_request.py
@@ -3,14 +3,11 @@
 
 import argparse
 import json
-import ssl
 import sys
 from http.client import HTTPResponse
 from pathlib import Path
 
 import requests
-from requests.exceptions import HTTPError
-
 from util import config, device_info, network_info
 
 
@@ -288,9 +285,9 @@ def main():
     except RuntimeError as re:
         print(re)
         sys.exit(1)
-    #except URLError as ue:
-    #    print("Connection failed:", ue)
-    #    sys.exit(1)
+    # except URLError as ue:
+    #     print("Connection failed:", ue)
+    #     sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/src/autopi/util/network_info.py
+++ b/src/autopi/util/network_info.py
@@ -35,12 +35,10 @@ def get_interfaces(exclude_loopback: bool = True) -> List[str]:
         list[str]: list of interface name strings
     """
     ref_ifaces = netifaces.interfaces()
-    up_ifaces = [x for x in ref_ifaces if get_interface_ip(x) is not None]
-    return [
-        x
-        for x in up_ifaces
-        if not (exclude_loopback and ip_address(get_interface_ip(x)).is_loopback)
-    ]
+    up_ifaces = (x for x in ref_ifaces if get_interface_ip(x) is not None)
+    if not exclude_loopback:
+        return list(up_ifaces)
+    return [x for x in up_ifaces if not ip_address(get_interface_ip(x)).is_loopback]
 
 
 def get_mac(interface: str) -> str:


### PR DESCRIPTION
# Description of changes
Convert generate_request to user 'requests' library instead of 'urllib'.
Fix bug in network_info (gateway is a function, crash if any interface down).

# Outstanding changes

# Outstanding questions

# Documentation updates
- [x] I updated usage documentation as appropriate
- [x] I updated installation documentation as appropriate
- [x] I updated implementation documentation as appropriate
- [x] I updated technical considerations documentation as appropriate

# Issues closed
closes #118 