### PR TITLE
Delete inactive users

### DIFF
--- a/src/web/database/autopi_schema.sql
+++ b/src/web/database/autopi_schema.sql
@@ -53,7 +53,7 @@ CREATE OR REPLACE FUNCTION check_expired() RETURNS TRIGGER
 	AS
 	$BODY$
 	BEGIN
-		DELETE FROM autopi.user WHERE (DATE_PART('day', autopi.user.last_login - NOW()) >= INTERVAL '365 days')
+		DELETE FROM autopi.user WHERE (NOW() - last_login) >= INTERVAL '365 days'
 			AND (autopi.user.is_admin == False);
 		RETURN NULL; 
 	END;


### PR DESCRIPTION
# Description of changes
- `ON DELETE CASCADE` for `raspi.warnings`
- delete users and pi's if pi is inactive for **1 YEAR**

# Outstanding changes
- still requires testing
# Outstanding questions

# Documentation updates
- [ ] I updated usage documentation as appropriate
- [ ] I updated installation documentation as appropriate
- [ ] I updated implementation documentation as appropriate
- [ ] I updated technical considerations documentation as appropriate

# Issues closed
closes #51 