### PR TITLE
Fix crash on warning exists

### DIFF
--- a/src/web/api/db.py
+++ b/src/web/api/db.py
@@ -330,7 +330,8 @@ class PiDBConnection:
         """
         query = """
             INSERT INTO autopi.raspi_warning (device_id, warning)
-            VALUES (%s, %s);
+            VALUES (%s, %s)
+            ON CONFLICT (device_id, warning) DO UPDATE SET added_at=NOW();
         """
         self._commit(query, (devid, warning))
 

--- a/src/web/api/main.py
+++ b/src/web/api/main.py
@@ -1,6 +1,5 @@
 """Test API server."""
 
-import psycopg2
 from fastapi import Cookie, FastAPI, HTTPException
 from fastapi.responses import HTMLResponse
 
@@ -129,10 +128,7 @@ def update_status(status: StatusModel):
         if prev_hwid != status.hwid:
             # TODO message should maybe not be defined in code??
             msg = "The hardware of this device has changed. If this was not you, contact your instructor."
-            try:
-                db.add_raspi_warning(status.devid, msg)
-            except psycopg2.errors.UniqueViolation:
-                pass  # warning already exists
+            db.add_raspi_warning(status.devid, msg)
 
         if status.event == "shutdown":
             db.update_status_shutdown(status)


### PR DESCRIPTION
# Description of changes
Fixes crash if hardware ID warning exists for the specified device.

# Outstanding changes

# Outstanding questions

# Documentation updates
- [x] I updated usage documentation as appropriate
- [x] I updated installation documentation as appropriate
- [x] I updated implementation documentation as appropriate
- [x] I updated technical considerations documentation as appropriate

# Issues closed
closes #139 
