### PR TITLE
Delete inactive users

### DIFF
--- a/src/web/database/autopi_schema.sql
+++ b/src/web/database/autopi_schema.sql
@@ -49,7 +49,7 @@ CREATE TRIGGER onupdate BEFORE UPDATE ON autopi.raspi FOR EACH ROW EXECUTE PROCE
 
 -- Add function and trigger to automatically delete users in users column if inactive for >= 1 year.
 
-CREATE OR REPLACE FUNCTION delete_expired() RETURNS TRIGGER
+CREATE OR REPLACE FUNCTION delete_expired_users() RETURNS TRIGGER
 	AS
 	$BODY$
 	BEGIN
@@ -59,4 +59,4 @@ CREATE OR REPLACE FUNCTION delete_expired() RETURNS TRIGGER
 	END;
 	$BODY$
 	LANGUAGE plpgsql;
-CREATE TRIGGER expired AFTER INSERT ON autopi.user FOR EACH STATEMENT EXECUTE PROCEDURE delete_expired();
+CREATE TRIGGER expired AFTER INSERT ON autopi.user FOR EACH STATEMENT EXECUTE PROCEDURE delete_expired_users();


### PR DESCRIPTION
# Description of changes
- `ON DELETE CASCADE` for `raspi.warnings`
- delete users and pi's if pi is inactive for **1 YEAR**

# Outstanding changes
- still requires testing
# Outstanding questions

# Documentation updates
- [ ] I updated usage documentation as appropriate
- [ ] I updated installation documentation as appropriate
- [ ] I updated implementation documentation as appropriate
- [ ] I updated technical considerations documentation as appropriate

# Issues closed
closes #51 