### PR TITLE
Add secure secret for private key

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -77,6 +77,6 @@ volumes:
 
 secrets:
   proxy_cert:
-    file: ./keys/autopi_server.cer
+    file: ./tls/autopi_server.cer
   proxy_pkey:
-    file: ./keys/autopi_server.key
+    file: ./tls/autopi_server.key


### PR DESCRIPTION
# Description of changes
Add secret for private key + certificate in docker compose. The certificate doesn't need security, but it turned out it was easier than mounting a file as a volume and there is no harm in it.

# Outstanding changes

# Outstanding questions

# Documentation updates
- [ ] I updated usage documentation as appropriate
- [ ] I updated installation documentation as appropriate
- [ ] I updated implementation documentation as appropriate
- [ ] I updated technical considerations documentation as appropriate

# Issues closed
