### PR TITLE
Keep whitespace around new networks

### DIFF
--- a/src/autopi/util/wpa_interface.py
+++ b/src/autopi/util/wpa_interface.py
@@ -210,7 +210,7 @@ def add_network(
         network_config = _strip_comment_lines(network_config)
 
     with open(config_file, "a") as fout:
-        fout.write(network_config)
+        fout.write("\n\n" + network_config + "\n")
     return True
 
 


### PR DESCRIPTION
# Description of changes
Added whitespace around new networks to ensure that networks will not overlap.

# Outstanding changes
None

# Outstanding questions
None

# Documentation updates
- [X] I updated usage documentation as appropriate
- [X] I updated installation documentation as appropriate
- [X] I updated implementation documentation as appropriate
- [X] I updated technical considerations documentation as appropriate

# Issues closed
Closes #160 